### PR TITLE
🔒 fix SSRF via unrestricted URL request

### DIFF
--- a/src/ai_agent/streamlit/website_summarizer.py
+++ b/src/ai_agent/streamlit/website_summarizer.py
@@ -2,6 +2,7 @@ import traceback
 import streamlit as st
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
+from urllib.parse import urlparse, urlunparse
 
 # models
 from langchain_openai import ChatOpenAI
@@ -83,15 +84,45 @@ def init_chain():
     return chain
 
 
-def get_content(url):
-    if not validate_url(url):
-        st.error("無効なURLまたは許可されていないURLです。")
-        return None
+def get_content(url, safe_ip):
+    """検証済みIPアドレスを使ってコンテンツを取得する (TOCTOU対策)。
 
+    Args:
+        url: 元のURL文字列
+        safe_ip: validate_url で検証済みのIPアドレス
+    """
     try:
         with st.spinner("Fetching content..."):
-            # Disable redirects to prevent SSRF bypass
-            response = requests.get(url, allow_redirects=False)
+            parsed_url = urlparse(url)
+
+            # IPv6アドレスの場合はブラケットで囲む
+            if ":" in safe_ip:
+                netloc = f"[{safe_ip}]"
+            else:
+                netloc = safe_ip
+
+            # ポートが指定されている場合は付加
+            if parsed_url.port:
+                netloc = f"{netloc}:{parsed_url.port}"
+
+            # IPアドレスでURLを再構築（パス・クエリ等は保持）
+            safe_request_url = urlunparse(
+                (
+                    parsed_url.scheme,
+                    netloc,
+                    parsed_url.path,
+                    parsed_url.params,
+                    parsed_url.query,
+                    parsed_url.fragment,
+                )
+            )
+
+            # 検証済みIPに直接リクエスト、Hostヘッダーで元のホスト名を指定
+            response = requests.get(
+                safe_request_url,
+                headers={"Host": parsed_url.hostname},
+                allow_redirects=False,
+            )
             if response.status_code in (301, 302, 303, 307, 308):
                 st.error("リダイレクトは許可されていません。")
                 return None
@@ -118,13 +149,13 @@ def main():
     chain = init_chain()
 
     if url := st.text_input("URL: ", key="input"):
-        is_valid_url = validate_url(url)
+        safe_ip = validate_url(url)
 
-        if not is_valid_url:
+        if not safe_ip:
             st.error("無効なURLです。")
             return
 
-        if content := get_content(url):
+        if content := get_content(url, safe_ip):
             st.markdown("## Summary")
             st.write_stream(chain.stream({"content": content}))
             st.markdown("---")

--- a/src/ai_agent/streamlit/website_summarizer.py
+++ b/src/ai_agent/streamlit/website_summarizer.py
@@ -10,7 +10,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 
 import requests
 from bs4 import BeautifulSoup
-from urllib.parse import urlparse
+from src.ai_agent.utils import validate_url
 
 SUMMARIZE_PROMPT = """
 以下のコンテンツについて、内容を300文字程度で、できるだけわかりやすく要約してください。
@@ -83,12 +83,6 @@ def init_chain():
     return chain
 
 
-def validate_url(url):
-    try:
-        result = urlparse(url)
-        return all([result.scheme, result.netloc])
-    except ValueError:
-        return False
 
 
 def get_content(url):

--- a/src/ai_agent/streamlit/website_summarizer.py
+++ b/src/ai_agent/streamlit/website_summarizer.py
@@ -10,7 +10,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 
 import requests
 from bs4 import BeautifulSoup
-from src.ai_agent.utils import validate_url
+from ai_agent.utils import validate_url
 
 SUMMARIZE_PROMPT = """
 以下のコンテンツについて、内容を300文字程度で、できるだけわかりやすく要約してください。
@@ -83,12 +83,19 @@ def init_chain():
     return chain
 
 
-
-
 def get_content(url):
+    if not validate_url(url):
+        st.error("無効なURLまたは許可されていないURLです。")
+        return None
+
     try:
         with st.spinner("Fetching content..."):
-            response = requests.get(url)
+            # Disable redirects to prevent SSRF bypass
+            response = requests.get(url, allow_redirects=False)
+            if response.status_code in (301, 302, 303, 307, 308):
+                st.error("リダイレクトは許可されていません。")
+                return None
+
             soup = BeautifulSoup(response.text, "html.parser")
             if soup.main:
                 return soup.main.get_text()

--- a/src/ai_agent/streamlit/youtube_summarizer.py
+++ b/src/ai_agent/streamlit/youtube_summarizer.py
@@ -9,7 +9,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
 
 from langchain_community.document_loaders import YoutubeLoader
-from ai_agent.utils import validate_url
+from ai_agent.utils import validate_youtube_url
 
 SUMMARIZE_PROMPT = """
 以下のコンテンツについて、内容を300文字程度で、できるだけわかりやすく要約してください。
@@ -96,7 +96,7 @@ def get_content(url):
             - length: int
             - author: str
     """
-    if not validate_url(url):
+    if not validate_youtube_url(url):
         st.error("無効なURLまたは許可されていないURLです。")
         return None
 
@@ -125,7 +125,7 @@ def main():
     chain = init_chain()
 
     if url := st.text_input("URL: ", key="input"):
-        is_valid_url = validate_url(url)
+        is_valid_url = validate_youtube_url(url)
 
         if not is_valid_url:
             st.error("無効なURLです。")

--- a/src/ai_agent/streamlit/youtube_summarizer.py
+++ b/src/ai_agent/streamlit/youtube_summarizer.py
@@ -9,7 +9,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
 
 from langchain_community.document_loaders import YoutubeLoader
-from urllib.parse import urlparse
+from src.ai_agent.utils import validate_url
 
 SUMMARIZE_PROMPT = """
 以下のコンテンツについて、内容を300文字程度で、できるだけわかりやすく要約してください。
@@ -82,12 +82,6 @@ def init_chain():
     return chain
 
 
-def validate_url(url):
-    try:
-        result = urlparse(url)
-        return all([result.scheme, result.netloc])
-    except ValueError:
-        return False
 
 
 def get_content(url):

--- a/src/ai_agent/streamlit/youtube_summarizer.py
+++ b/src/ai_agent/streamlit/youtube_summarizer.py
@@ -9,7 +9,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
 
 from langchain_community.document_loaders import YoutubeLoader
-from src.ai_agent.utils import validate_url
+from ai_agent.utils import validate_url
 
 SUMMARIZE_PROMPT = """
 以下のコンテンツについて、内容を300文字程度で、できるだけわかりやすく要約してください。
@@ -82,9 +82,11 @@ def init_chain():
     return chain
 
 
-
-
 def get_content(url):
+    if not validate_url(url):
+        st.error("無効なURLまたは許可されていないURLです。")
+        return None
+
     """
     Document:
         - page_content: str

--- a/src/ai_agent/streamlit/youtube_summarizer.py
+++ b/src/ai_agent/streamlit/youtube_summarizer.py
@@ -83,10 +83,6 @@ def init_chain():
 
 
 def get_content(url):
-    if not validate_url(url):
-        st.error("無効なURLまたは許可されていないURLです。")
-        return None
-
     """
     Document:
         - page_content: str
@@ -100,6 +96,10 @@ def get_content(url):
             - length: int
             - author: str
     """
+    if not validate_url(url):
+        st.error("無効なURLまたは許可されていないURLです。")
+        return None
+
     with st.spinner("Fetching content..."):
         loader = YoutubeLoader.from_youtube_url(
             url,

--- a/src/ai_agent/utils.py
+++ b/src/ai_agent/utils.py
@@ -1,6 +1,7 @@
-import socket
 import ipaddress
+import socket
 from urllib.parse import urlparse
+
 
 def validate_url(url):
     try:

--- a/src/ai_agent/utils.py
+++ b/src/ai_agent/utils.py
@@ -2,8 +2,73 @@ import ipaddress
 import socket
 from urllib.parse import urlparse
 
+# YouTube で許可されるドメインのホワイトリスト
+YOUTUBE_ALLOWED_DOMAINS = {
+    "www.youtube.com",
+    "youtube.com",
+    "youtu.be",
+    "m.youtube.com",
+}
+
 
 def validate_url(url):
+    """URLを検証し、安全であれば解決済みIPアドレスを返す。
+
+    TOCTOU対策: 検証済みのIPアドレスを返すことで、
+    呼び出し元が同じIPに対して直接リクエストを送信可能。
+
+    Args:
+        url: 検証対象のURL文字列
+
+    Returns:
+        str: 安全な解決済みIPアドレス（検証成功時）
+        None: 検証失敗時
+    """
+    try:
+        result = urlparse(url)
+        if not all([result.scheme, result.netloc]):
+            return None
+        if result.scheme not in ["http", "https"]:
+            return None
+
+        hostname = result.hostname
+        if not hostname:
+            return None
+
+        # Resolve hostname to IP addresses and check each one
+        addr_info = socket.getaddrinfo(hostname, None)
+        for _, _, _, _, sockaddr in addr_info:
+            ip_addr = sockaddr[0]
+            ip = ipaddress.ip_address(ip_addr)
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_unspecified
+                or ip.is_multicast
+                or ip.is_reserved
+            ):
+                return None
+
+        # Return the first resolved safe IP address
+        first_ip = addr_info[0][4][0]
+        return first_ip
+    except (ValueError, socket.gaierror):
+        return None
+
+
+def validate_youtube_url(url):
+    """YouTube URLを検証する。
+
+    YouTubeドメインのホワイトリストで検証し、
+    さらにIPアドレスの安全性も確認する。
+
+    Args:
+        url: 検証対象のURL文字列
+
+    Returns:
+        bool: 検証成功時True、失敗時False
+    """
     try:
         result = urlparse(url)
         if not all([result.scheme, result.netloc]):
@@ -15,7 +80,11 @@ def validate_url(url):
         if not hostname:
             return False
 
-        # Resolve hostname to IP addresses and check each one
+        # YouTube ドメインのホワイトリスト検証
+        if hostname not in YOUTUBE_ALLOWED_DOMAINS:
+            return False
+
+        # IPアドレスの安全性も確認
         addr_info = socket.getaddrinfo(hostname, None)
         for _, _, _, _, sockaddr in addr_info:
             ip_addr = sockaddr[0]

--- a/src/ai_agent/utils.py
+++ b/src/ai_agent/utils.py
@@ -1,0 +1,34 @@
+import socket
+import ipaddress
+from urllib.parse import urlparse
+
+def validate_url(url):
+    try:
+        result = urlparse(url)
+        if not all([result.scheme, result.netloc]):
+            return False
+        if result.scheme not in ["http", "https"]:
+            return False
+
+        hostname = result.hostname
+        if not hostname:
+            return False
+
+        # Resolve hostname to IP addresses and check each one
+        addr_info = socket.getaddrinfo(hostname, None)
+        for _, _, _, _, sockaddr in addr_info:
+            ip_addr = sockaddr[0]
+            ip = ipaddress.ip_address(ip_addr)
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_unspecified
+                or ip.is_multicast
+                or ip.is_reserved
+            ):
+                return False
+
+        return True
+    except (ValueError, socket.gaierror):
+        return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
-import ipaddress
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from ai_agent.utils import validate_url, validate_youtube_url
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,103 @@
+import ipaddress
+from unittest.mock import patch, MagicMock
+from ai_agent.utils import validate_url, validate_youtube_url
+
+
+class TestValidateUrl:
+    """validate_url のテスト"""
+
+    @patch("ai_agent.utils.socket.getaddrinfo")
+    def test_valid_public_url_returns_ip(self, mock_getaddrinfo):
+        """安全な公開URLに対してIPアドレス文字列を返すこと"""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+        ]
+        result = validate_url("https://example.com")
+        assert result == "93.184.216.34"
+
+    @patch("ai_agent.utils.socket.getaddrinfo")
+    def test_private_ip_returns_none(self, mock_getaddrinfo):
+        """プライベートIPに解決されるURLにはNoneを返すこと"""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("192.168.1.1", 0)),
+        ]
+        result = validate_url("https://internal.example.com")
+        assert result is None
+
+    @patch("ai_agent.utils.socket.getaddrinfo")
+    def test_loopback_ip_returns_none(self, mock_getaddrinfo):
+        """ループバックIPに解決されるURLにはNoneを返すこと"""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]
+        result = validate_url("https://localhost.example.com")
+        assert result is None
+
+    @patch("ai_agent.utils.socket.getaddrinfo")
+    def test_link_local_ip_returns_none(self, mock_getaddrinfo):
+        """リンクローカルIPに解決されるURLにはNoneを返すこと"""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("169.254.1.1", 0)),
+        ]
+        result = validate_url("https://linklocal.example.com")
+        assert result is None
+
+    def test_invalid_scheme_returns_none(self):
+        """http/https以外のスキームにはNoneを返すこと"""
+        assert validate_url("ftp://example.com") is None
+        assert validate_url("file:///etc/passwd") is None
+
+    def test_no_scheme_returns_none(self):
+        """スキームなしURLにはNoneを返すこと"""
+        assert validate_url("example.com") is None
+
+    def test_empty_string_returns_none(self):
+        """空文字にはNoneを返すこと"""
+        assert validate_url("") is None
+
+    def test_returns_string_type(self):
+        """戻り値がstr型またはNoneであること"""
+        result = validate_url("")
+        assert result is None
+
+    @patch("ai_agent.utils.socket.getaddrinfo")
+    def test_multiple_ips_with_one_private_returns_none(self, mock_getaddrinfo):
+        """複数IP解決のうち1つでもプライベートならNoneを返すこと"""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+            (2, 1, 6, "", ("10.0.0.1", 0)),
+        ]
+        result = validate_url("https://mixed.example.com")
+        assert result is None
+
+
+class TestValidateYoutubeUrl:
+    """validate_youtube_url のテスト"""
+
+    @patch("ai_agent.utils.socket.getaddrinfo")
+    def test_valid_youtube_url(self, mock_getaddrinfo):
+        """正規YouTubeURLはTrueを返すこと"""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("142.250.185.206", 0)),
+        ]
+        assert validate_youtube_url("https://www.youtube.com/watch?v=abc123") is True
+
+    @patch("ai_agent.utils.socket.getaddrinfo")
+    def test_valid_youtu_be_url(self, mock_getaddrinfo):
+        """短縮YouTubeURLはTrueを返すこと"""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("142.250.185.206", 0)),
+        ]
+        assert validate_youtube_url("https://youtu.be/abc123") is True
+
+    def test_non_youtube_domain_returns_false(self):
+        """YouTube以外のドメインはFalseを返すこと"""
+        assert validate_youtube_url("https://evil.com/watch?v=abc123") is False
+
+    def test_invalid_scheme_returns_false(self):
+        """不正スキームはFalseを返すこと"""
+        assert validate_youtube_url("ftp://www.youtube.com/watch?v=abc123") is False
+
+    def test_empty_url_returns_false(self):
+        """空URLはFalseを返すこと"""
+        assert validate_youtube_url("") is False


### PR DESCRIPTION
### 🎯 What:
Fixed a Server-Side Request Forgery (SSRF) vulnerability in `website_summarizer.py` and `youtube_summarizer.py`.

### ⚠️ Risk:
An attacker could provide a URL pointing to internal services (e.g., `http://localhost:8080`, `http://169.254.169.254`) to probe the internal network, bypass firewalls, or access sensitive metadata from cloud providers.

### 🛡️ Solution:
Implemented a secure `validate_url` function in a new shared utility file `src/ai_agent/utils.py`. The function:
- Restricts schemes to `http` and `https`.
- Resolves hostnames to all associated IP addresses.
- Verifies that none of the resolved IPs fall within private, loopback, link-local, multicast, or reserved ranges using the `ipaddress` module.
- Refactored both vulnerable components to use this shared validation logic.


---
*PR created automatically by Jules for task [4054372181712710967](https://jules.google.com/task/4054372181712710967) started by @kurousa*