### PR TITLE
🔒 Add timeout to HTTP request in website_summarizer

### DIFF
--- a/src/ai_agent/streamlit/website_summarizer.py
+++ b/src/ai_agent/streamlit/website_summarizer.py
@@ -122,6 +122,7 @@ def get_content(url, safe_ip):
                 safe_request_url,
                 headers={"Host": parsed_url.hostname},
                 allow_redirects=False,
+                timeout=10,
             )
             if response.status_code in (301, 302, 303, 307, 308):
                 st.error("リダイレクトは許可されていません。")

--- a/tests/test_website_summarizer.py
+++ b/tests/test_website_summarizer.py
@@ -1,28 +1,30 @@
-import unittest
-from unittest.mock import patch, MagicMock
-import sys
 import os
-
-# Mock streamlit and requests before importing the target module
-sys.modules['streamlit'] = MagicMock()
-sys.modules['langchain_core'] = MagicMock()
-sys.modules['langchain_core.prompts'] = MagicMock()
-sys.modules['langchain_core.output_parsers'] = MagicMock()
-sys.modules['langchain_openai'] = MagicMock()
-sys.modules['langchain_anthropic'] = MagicMock()
-sys.modules['langchain_google_genai'] = MagicMock()
-sys.modules['requests'] = MagicMock()
-sys.modules['bs4'] = MagicMock()
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
 
 # Add src to sys.path
-sys.path.append(os.path.join(os.getcwd(), 'src'))
+sys.path.append(os.path.join(os.getcwd(), "src"))
 
-from ai_agent.streamlit.website_summarizer import get_content
+# Mock modules that are not installed to allow importing the target module
+sys.modules["streamlit"] = MagicMock()
+sys.modules["langchain_core"] = MagicMock()
+sys.modules["langchain_core.prompts"] = MagicMock()
+sys.modules["langchain_core.output_parsers"] = MagicMock()
+sys.modules["langchain_openai"] = MagicMock()
+sys.modules["langchain_anthropic"] = MagicMock()
+sys.modules["langchain_google_genai"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+sys.modules["bs4"] = MagicMock()
+
+# E402: Module level import not at top of file.
+# We need to mock sys.modules before this import.
+from ai_agent.streamlit.website_summarizer import get_content  # noqa: E402
+
 
 class TestWebsiteSummarizer(unittest.TestCase):
-    @patch('ai_agent.streamlit.website_summarizer.requests.get')
+    @patch("ai_agent.streamlit.website_summarizer.requests.get")
     def test_get_content_timeout(self, mock_get):
-        import requests
         # Setup mock
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -30,7 +32,7 @@ class TestWebsiteSummarizer(unittest.TestCase):
         mock_get.return_value = mock_response
 
         # Mock BeautifulSoup
-        with patch('ai_agent.streamlit.website_summarizer.BeautifulSoup') as mock_bs:
+        with patch("ai_agent.streamlit.website_summarizer.BeautifulSoup") as mock_bs:
             mock_soup = MagicMock()
             mock_soup.main = None
             mock_soup.article = None
@@ -44,8 +46,9 @@ class TestWebsiteSummarizer(unittest.TestCase):
 
             # Check if requests.get was called with timeout=10
             mock_get.assert_called_once()
-            args, kwargs = mock_get.call_args
-            self.assertEqual(kwargs.get('timeout'), 10)
+            _, kwargs = mock_get.call_args
+            self.assertEqual(kwargs.get("timeout"), 10)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_website_summarizer.py
+++ b/tests/test_website_summarizer.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Mock streamlit and requests before importing the target module
+sys.modules['streamlit'] = MagicMock()
+sys.modules['langchain_core'] = MagicMock()
+sys.modules['langchain_core.prompts'] = MagicMock()
+sys.modules['langchain_core.output_parsers'] = MagicMock()
+sys.modules['langchain_openai'] = MagicMock()
+sys.modules['langchain_anthropic'] = MagicMock()
+sys.modules['langchain_google_genai'] = MagicMock()
+sys.modules['requests'] = MagicMock()
+sys.modules['bs4'] = MagicMock()
+
+# Add src to sys.path
+sys.path.append(os.path.join(os.getcwd(), 'src'))
+
+from ai_agent.streamlit.website_summarizer import get_content
+
+class TestWebsiteSummarizer(unittest.TestCase):
+    @patch('ai_agent.streamlit.website_summarizer.requests.get')
+    def test_get_content_timeout(self, mock_get):
+        import requests
+        # Setup mock
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "<html><body>Content</body></html>"
+        mock_get.return_value = mock_response
+
+        # Mock BeautifulSoup
+        with patch('ai_agent.streamlit.website_summarizer.BeautifulSoup') as mock_bs:
+            mock_soup = MagicMock()
+            mock_soup.main = None
+            mock_soup.article = None
+            mock_soup.body.get_text.return_value = "Content"
+            mock_bs.return_value = mock_soup
+
+            # Call the function
+            url = "http://example.com"
+            safe_ip = "93.184.216.34"
+            get_content(url, safe_ip)
+
+            # Check if requests.get was called with timeout=10
+            mock_get.assert_called_once()
+            args, kwargs = mock_get.call_args
+            self.assertEqual(kwargs.get('timeout'), 10)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Missing timeout on a `requests.get` call in `src/ai_agent/streamlit/website_summarizer.py`.

### ⚠️ Risk: The potential impact if left unfixed
An attacker could provide a URL to a slow-responding or "hanging" server, causing the Streamlit application thread to block indefinitely. This could lead to resource exhaustion and a Denial of Service (DoS) for other users.

### 🛡️ Solution: How the fix addresses the vulnerability
Added `timeout=10` to the `requests.get` call. This ensures that the request will fail and the resources will be released if the server does not respond within 10 seconds. Added unit tests with mocks to verify that the timeout parameter is correctly passed.

---
*PR created automatically by Jules for task [15793737263122980491](https://jules.google.com/task/15793737263122980491) started by @kurousa*