### PR TITLE
🔒 fix: Prevent prompt injection in YouTube summarizer

### DIFF
--- a/src/ai_agent/streamlit/youtube_summarizer.py
+++ b/src/ai_agent/streamlit/youtube_summarizer.py
@@ -11,13 +11,8 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_community.document_loaders import YoutubeLoader
 from ai_agent.utils import validate_youtube_url
 
-SUMMARIZE_PROMPT = """
+SYSTEM_PROMPT = """
 以下のコンテンツについて、内容を300文字程度で、できるだけわかりやすく要約してください。
-
-==========
-{content}
-==========
-
 回答は、日本語で行うこと。
 """
 
@@ -74,7 +69,8 @@ def init_chain():
     llm = select_model()
     prompt = ChatPromptTemplate.from_messages(
         [
-            ("user", SUMMARIZE_PROMPT),
+            ("system", SYSTEM_PROMPT),
+            ("user", "{content}"),
         ]
     )
     output_parser = StrOutputParser()

--- a/tests/test_youtube_summarizer.py
+++ b/tests/test_youtube_summarizer.py
@@ -72,7 +72,9 @@ with patch.dict("sys.modules", MOCK_MODULES):
 
 @patch.object(youtube_summarizer, "select_model")
 @patch.object(youtube_summarizer, "ChatPromptTemplate")
-def test_youtube_summarizer_prompt_structure(mock_chat_prompt_template, mock_select_model):
+def test_youtube_summarizer_prompt_structure(
+    mock_chat_prompt_template, mock_select_model
+):
     """Verify that the prompt correctly separates system instructions and user content to prevent prompt injection."""
 
     mock_select_model.return_value = MagicMock()
@@ -96,4 +98,6 @@ def test_youtube_summarizer_prompt_structure(mock_chat_prompt_template, mock_sel
 
     user_role, user_content = messages[1]
     assert user_role == "user", "Second message should be the user content"
-    assert user_content == "{content}", "User message should just be the content variable"
+    assert user_content == "{content}", (
+        "User message should just be the content variable"
+    )

--- a/tests/test_youtube_summarizer.py
+++ b/tests/test_youtube_summarizer.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from ai_agent.utils import validate_url, validate_youtube_url
 
 
@@ -53,3 +53,47 @@ def test_validate_youtube_url_valid():
 
 def test_validate_youtube_url_non_youtube():
     assert validate_youtube_url("https://evil.com/watch?v=abc") is False
+
+
+MOCK_MODULES = {
+    "streamlit": MagicMock(),
+    "langchain_core": MagicMock(),
+    "langchain_core.prompts": MagicMock(),
+    "langchain_core.output_parsers": MagicMock(),
+    "langchain_openai": MagicMock(),
+    "langchain_anthropic": MagicMock(),
+    "langchain_google_genai": MagicMock(),
+    "langchain_community.document_loaders": MagicMock(),
+}
+
+with patch.dict("sys.modules", MOCK_MODULES):
+    import ai_agent.streamlit.youtube_summarizer as youtube_summarizer  # noqa: E402
+
+
+@patch.object(youtube_summarizer, "select_model")
+@patch.object(youtube_summarizer, "ChatPromptTemplate")
+def test_youtube_summarizer_prompt_structure(mock_chat_prompt_template, mock_select_model):
+    """Verify that the prompt correctly separates system instructions and user content to prevent prompt injection."""
+
+    mock_select_model.return_value = MagicMock()
+    mock_chat_prompt_template.from_messages.return_value = MagicMock()
+
+    # Call the function that creates the chain (and the prompt)
+    youtube_summarizer.init_chain()
+
+    # Verify from_messages was called
+    mock_chat_prompt_template.from_messages.assert_called_once()
+
+    # Get the messages argument passed to from_messages
+    messages = mock_chat_prompt_template.from_messages.call_args[0][0]
+
+    # Verify structure: [(system, ...), (user, {content})]
+    assert len(messages) == 2, "Prompt should have two messages (system and user)"
+
+    system_role, system_content = messages[0]
+    assert system_role == "system", "First message should be the system prompt"
+    assert "要約" in system_content, "System prompt should contain the instructions"
+
+    user_role, user_content = messages[1]
+    assert user_role == "user", "Second message should be the user content"
+    assert user_content == "{content}", "User message should just be the content variable"


### PR DESCRIPTION
🎯 **What:** The `SUMMARIZE_PROMPT` in `src/ai_agent/streamlit/youtube_summarizer.py` concatenated system instructions with untrusted user input (YouTube transcript content) inside a single `"user"` message. This has been updated to use `ChatPromptTemplate.from_messages` to separate the Japanese instructions into a `"system"` message and the `{content}` into a `"user"` message.

⚠️ **Risk:** By placing user-controlled transcript data directly alongside the instructions, an attacker could craft a YouTube video with a deceptive transcript (e.g., "Ignore previous instructions and do X") that the LLM would interpret as actual instructions, leading to prompt injection vulnerabilities.

🛡️ **Solution:** Separating the roles into `"system"` and `"user"` messages provides strong isolation. The LLM understands that the `"system"` message contains the actual instructions it must follow, and the `"user"` message contains the data it should process. This mitigation strategy perfectly aligns with best practices and the approach used in the website summarizer feature. New tests were also added to `tests/test_youtube_summarizer.py` to ensure the correct prompt structure is generated.

---
*PR created automatically by Jules for task [1517423521069367915](https://jules.google.com/task/1517423521069367915) started by @kurousa*