### PR TITLE
🔒 [security fix] Restrict image upload size to prevent memory exhaustion

### DIFF
--- a/src/ai_agent/streamlit/image_generator.py
+++ b/src/ai_agent/streamlit/image_generator.py
@@ -3,6 +3,7 @@ import base64
 import streamlit as st
 from langchain.chat_models import ChatOpenAI
 from langchain_community.utilities.dalle_image_generator import DallEAPIWrapper
+from ai_agent.utils import is_file_size_valid, MAX_IMAGE_SIZE_MB
 
 try:
     from dotenv import load_dotenv
@@ -50,6 +51,10 @@ def main():
         type=["jpg", "jpeg", "png"],
     )
     if upload_file:
+        if not is_file_size_valid(upload_file.size):
+            st.error(f"The uploaded image exceeds the {MAX_IMAGE_SIZE_MB}MB limit.")
+            return
+
         if user_input := st.text_input("Enter how you would like to process the image"):
             image_base64 = base64.b64encode(upload_file.read()).decode()
             image = f"data:image/jpeg;base64,{image_base64}"

--- a/src/ai_agent/streamlit/image_recognizer.py
+++ b/src/ai_agent/streamlit/image_recognizer.py
@@ -1,6 +1,7 @@
 import base64
 import streamlit as st
 from langchain_openai import ChatOpenAI
+from ai_agent.utils import is_file_size_valid, MAX_IMAGE_SIZE_MB
 
 try:
     from dotenv import load_dotenv
@@ -29,6 +30,10 @@ def main():
         type=["jpg", "jpeg", "png"],
     )
     if upload_file:
+        if not is_file_size_valid(upload_file.size):
+            st.error(f"The uploaded image exceeds the {MAX_IMAGE_SIZE_MB}MB limit.")
+            return
+
         if user_input := st.text_input("Enter a description of the image"):
             image_base64 = base64.b64encode(upload_file.read()).decode()
             image = f"data:image/jpeg;base64,{image_base64}"

--- a/src/ai_agent/utils.py
+++ b/src/ai_agent/utils.py
@@ -10,6 +10,22 @@ YOUTUBE_ALLOWED_DOMAINS = {
     "m.youtube.com",
 }
 
+# 最大画像サイズ (MB)
+MAX_IMAGE_SIZE_MB = 5
+MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024
+
+
+def is_file_size_valid(file_size: int) -> bool:
+    """ファイルサイズが制限内であるかを確認する。
+
+    Args:
+        file_size: ファイルサイズ（バイト）
+
+    Returns:
+        bool: 制限内であればTrue、そうでなければFalse
+    """
+    return file_size <= MAX_IMAGE_SIZE_BYTES
+
 
 def validate_url(url):
     """URLを検証し、安全であれば解決済みIPアドレスを返す。

--- a/tests/test_image_upload_validation.py
+++ b/tests/test_image_upload_validation.py
@@ -1,0 +1,28 @@
+from ai_agent.utils import is_file_size_valid, MAX_IMAGE_SIZE_BYTES
+
+
+def test_is_file_size_valid_under_limit():
+    """制限内のファイルサイズに対してTrueを返すこと"""
+    assert is_file_size_valid(MAX_IMAGE_SIZE_BYTES - 1) is True
+
+
+def test_is_file_size_valid_at_limit():
+    """制限ぴったりのファイルサイズに対してTrueを返すこと"""
+    assert is_file_size_valid(MAX_IMAGE_SIZE_BYTES) is True
+
+
+def test_is_file_size_valid_over_limit():
+    """制限を超えるファイルサイズに対してFalseを返すこと"""
+    assert is_file_size_valid(MAX_IMAGE_SIZE_BYTES + 1) is False
+
+
+def test_is_file_size_valid_zero():
+    """サイズ0に対してTrueを返すこと"""
+    assert is_file_size_valid(0) is True
+
+if __name__ == "__main__":
+    test_is_file_size_valid_under_limit()
+    test_is_file_size_valid_at_limit()
+    test_is_file_size_valid_over_limit()
+    test_is_file_size_valid_zero()
+    print("All tests passed!")

--- a/tests/test_image_upload_validation.py
+++ b/tests/test_image_upload_validation.py
@@ -20,6 +20,7 @@ def test_is_file_size_valid_zero():
     """サイズ0に対してTrueを返すこと"""
     assert is_file_size_valid(0) is True
 
+
 if __name__ == "__main__":
     test_is_file_size_valid_under_limit()
     test_is_file_size_valid_at_limit()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is unrestricted memory usage when processing uploaded images.
⚠️ **Risk:** An attacker could upload an extremely large image, which would then be read into memory and base64 encoded. This could lead to a Denial of Service (DoS) by exhausting the server's memory.
🛡️ **Solution:** Implemented a file size check in `src/ai_agent/utils.py` and integrated it into `image_recognizer.py` and `image_generator.py`. Uploaded images are now limited to 5MB. Added unit tests for the validation logic.

---
*PR created automatically by Jules for task [4798181097991493212](https://jules.google.com/task/4798181097991493212) started by @kurousa*