### PR TITLE
🧹 fix: update deprecated LangChain import in image_generator.py

### DIFF
--- a/src/ai_agent/streamlit/image_generator.py
+++ b/src/ai_agent/streamlit/image_generator.py
@@ -1,7 +1,7 @@
 import html
 import base64
 import streamlit as st
-from langchain.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from langchain_community.utilities.dalle_image_generator import DallEAPIWrapper
 
 try:


### PR DESCRIPTION
This PR updates `src/ai_agent/streamlit/image_generator.py` to use the non-deprecated `ChatOpenAI` import from `langchain_openai` instead of `langchain.chat_models`. This change aligns the file with modern LangChain practices and avoids potential future compatibility issues. 

🎯 **What:** Replaced `from langchain.chat_models import ChatOpenAI` with `from langchain_openai import ChatOpenAI`.
💡 **Why:** The previous import was deprecated and moved to provider-specific packages like `langchain-openai`.
✅ **Verification:**
- Successfully verified the module's ability to import `ChatOpenAI` from `langchain_openai` by mocking required dependencies.
- Confirmed that all existing project tests pass.
- Verified that the file passes `ruff` linting and formatting checks.
✨ **Result:** The codebase is cleaner and follows current LangChain recommendations.

---
*PR created automatically by Jules for task [490892737449917538](https://jules.google.com/task/490892737449917538) started by @kurousa*