### PR TITLE
🧪 [testing improvement] Add error handling test for get_content in youtube_summarizer.py

### DIFF
--- a/src/ai_agent/streamlit/youtube_summarizer.py
+++ b/src/ai_agent/streamlit/youtube_summarizer.py
@@ -97,13 +97,13 @@ def get_content(url):
         return None
 
     with st.spinner("Fetching content..."):
-        loader = YoutubeLoader.from_youtube_url(
-            url,
-            add_video_info=True,
-            language=["en", "ja"],
-        )
-        res = loader.load()
         try:
+            loader = YoutubeLoader.from_youtube_url(
+                url,
+                add_video_info=True,
+                language=["en", "ja"],
+            )
+            res = loader.load()
             if res:
                 content = res[0].page_content
                 title = res[0].metadata["title"]

--- a/tests/test_youtube_summarizer.py
+++ b/tests/test_youtube_summarizer.py
@@ -110,7 +110,9 @@ def test_get_content_error_handling(mock_validate_youtube_url):
 
     # Get the mocked streamlit and loader from MOCK_MODULES
     mock_st = MOCK_MODULES["streamlit"]
-    mock_loader_class = MOCK_MODULES["langchain_community.document_loaders"].YoutubeLoader
+    mock_loader_class = MOCK_MODULES[
+        "langchain_community.document_loaders"
+    ].YoutubeLoader
 
     # Setup the mock to raise an exception when load() is called
     mock_loader_instance = MagicMock()
@@ -122,4 +124,6 @@ def test_get_content_error_handling(mock_validate_youtube_url):
 
     # Verify results
     assert result is None
-    mock_st.error.assert_called_with("Failed to fetch content from the URL: Test exception")
+    mock_st.error.assert_called_with(
+        "Failed to fetch content from the URL: Test exception"
+    )

--- a/tests/test_youtube_summarizer.py
+++ b/tests/test_youtube_summarizer.py
@@ -101,3 +101,25 @@ def test_youtube_summarizer_prompt_structure(
     assert user_content == "{content}", (
         "User message should just be the content variable"
     )
+
+
+@patch.object(youtube_summarizer, "validate_youtube_url")
+def test_get_content_error_handling(mock_validate_youtube_url):
+    """get_content() handles exceptions from YoutubeLoader correctly."""
+    mock_validate_youtube_url.return_value = True
+
+    # Get the mocked streamlit and loader from MOCK_MODULES
+    mock_st = MOCK_MODULES["streamlit"]
+    mock_loader_class = MOCK_MODULES["langchain_community.document_loaders"].YoutubeLoader
+
+    # Setup the mock to raise an exception when load() is called
+    mock_loader_instance = MagicMock()
+    mock_loader_instance.load.side_effect = Exception("Test exception")
+    mock_loader_class.from_youtube_url.return_value = mock_loader_instance
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    result = youtube_summarizer.get_content(url)
+
+    # Verify results
+    assert result is None
+    mock_st.error.assert_called_with("Failed to fetch content from the URL: Test exception")


### PR DESCRIPTION
This PR addresses a testing gap in `get_content()` within `src/ai_agent/streamlit/youtube_summarizer.py`.

### Changes:
- **Refactor:** Moved `YoutubeLoader.from_youtube_url()` and `loader.load()` calls inside the `try...except` block in `get_content()` to ensure exceptions (e.g., network issues, invalid video IDs) are caught and handled by showing an error message in Streamlit.
- **Testing:** Added `test_get_content_error_handling` to `tests/test_youtube_summarizer.py`. This test mocks `YoutubeLoader` to raise an exception and verifies that:
  - `get_content()` returns `None`.
  - `st.error()` is called with the expected error message.

### Coverage:
- Verified error handling path when fetching content from YouTube fails.
- All existing tests in `tests/test_youtube_summarizer.py` and the full suite continue to pass.

✨ Result: Improved reliability of error reporting and confirmed coverage for failure scenarios in the YouTube summarizer.

---
*PR created automatically by Jules for task [1181376850346179853](https://jules.google.com/task/1181376850346179853) started by @kurousa*