### PR TITLE
🔒 [security fix: escape markdown in transcript and website content]

### DIFF
--- a/src/ai_agent/streamlit/image_generator.py
+++ b/src/ai_agent/streamlit/image_generator.py
@@ -98,7 +98,7 @@ def main():
 
     if dalle3_image_url:
         st.markdown("### Generated Image")
-        st.write(user_input)
+        st.text(user_input)
         st.image(upload_file, use_column_width="auto")
 
         st.markdown("### Generated Image by DALL-E 3")

--- a/src/ai_agent/streamlit/image_recognizer.py
+++ b/src/ai_agent/streamlit/image_recognizer.py
@@ -53,7 +53,7 @@ def main():
                 )
             ]
             st.markdown("### Question")
-            st.write(user_input)
+            st.text(user_input)
             st.image(upload_file)
             st.markdown("### Answer")
             st.write_stream(llm.stream(query))

--- a/src/ai_agent/streamlit/website_summarizer.py
+++ b/src/ai_agent/streamlit/website_summarizer.py
@@ -167,7 +167,7 @@ def main():
             st.write_stream(chain.stream({"content": content}))
             st.markdown("---")
             st.markdown("## Original Content")
-            st.write(content)
+            st.text(content)
 
 
 if __name__ == "__main__":

--- a/src/ai_agent/streamlit/youtube_summarizer.py
+++ b/src/ai_agent/streamlit/youtube_summarizer.py
@@ -132,7 +132,7 @@ def main():
             st.write_stream(chain.stream({"content": content}))
             st.markdown("---")
             st.markdown("## Original Content")
-            st.write(content)
+            st.text(content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The vulnerability was that untrusted external content (YouTube transcripts, website scrapes) and raw user inputs were being displayed using `st.write()`, which in Streamlit can render Markdown or HTML. This could lead to Cross-Site Scripting (XSS) if the content contained malicious scripts or links.

Fixed:
- Replaced `st.write(content)` with `st.text(content)` in `src/ai_agent/streamlit/youtube_summarizer.py` and `src/ai_agent/streamlit/website_summarizer.py`.
- Replaced `st.write(user_input)` with `st.text(user_input)` in `src/ai_agent/streamlit/image_recognizer.py` and `src/ai_agent/streamlit/image_generator.py`.

Impact:
This ensures that all potentially untrusted content is displayed as raw text, preventing any Markdown or HTML injection.

Verification:
- Manual code inspection confirmed that all instances were correctly updated to use `st.text()`.
- Existing unit tests passed successfully.
- Code review confirmed the fix is correct and aligns with Streamlit security best practices.

---
*PR created automatically by Jules for task [16740305237706636748](https://jules.google.com/task/16740305237706636748) started by @kurousa*